### PR TITLE
Fix PR docker image test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
+          # Load the image into the local Docker daemon for PRs so it can be tested
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- adjust Docker workflow so PR builds load the image into the local Docker daemon for testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googlemaps')*

------
https://chatgpt.com/codex/tasks/task_e_684f0949794c83208884ab349824a699