### PR TITLE
Remove Docker test stage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,8 +73,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Test Docker image
-        if: github.event_name == 'pull_request'
-        run: |
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} help


### PR DESCRIPTION
## Summary
- remove the `Test Docker image` step from the GitHub Actions workflow

## Testing
- `python -m pytest -q` *(fails: Should have overnight markers)*

------
https://chatgpt.com/codex/tasks/task_e_684f28d0289c83209d0dfa30b16fa1f0